### PR TITLE
hotfix announcement banner always showed localhost in production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,4 +23,4 @@ jobs:
           export PROJECT_NAME=$(echo ${GITHUB_REPOSITORY#*/})
           git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
           git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
-          cd documentation && yarn deploy
+          cd documentation && NODE_ENV="production" yarn deploy


### PR DESCRIPTION
# Fix Production Banner Bug
There’s a bug in Docusaurus that causes this banner to appear on the production webpage.

Here’s the image: <img width="784" alt="Screenshot 2025-05-28 at 4 09 51 PM" src="https://github.com/user-attachments/assets/33bfdd78-365c-4df3-a537-4fd5f699981e" />

This pull request fixes this issue. 